### PR TITLE
changed string concatenations to f-strings, fixed two typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Code style
 - Use tabs.
-- Use signle quotes `'` and not double quotes `"`.
+- Use single quotes `'` and not double quotes `"`.
 - If you have to use some sort of string formating use f-strings.
 - Don't put unneccesary comments.
 - Follow the PEP8 guidelines, ex. two empty lines between methods.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 ```
 
 ## Get started
-- Download the `aks.py` file. You can also download `ask-watcher.py` if you want to use live transpilation.
+- Download the `ask.py` file. You can also download `ask-watcher.py` if you want to use live transpilation.
 - Write your code in a `.ask` file
 - Download `requirements.txt`, and install the requirements (`pip3 install -r requirements.txt`)
 - Transpile your code to Flask (Python) with `python3 ask.py [your file].ask`

--- a/ask.py
+++ b/ask.py
@@ -25,7 +25,7 @@ def get_ask_config(source_root):
 	if source_root:
 		source_root += '/'
 
-	if os.path.isfile(f'{source_root}Askfile':
+	if os.path.isfile(f'{source_root}Askfile'):
 		with open(f'{source_root}Askfile', 'r') as f:
 			return json.loads(''.join(f.readlines()))
 

--- a/ask.py
+++ b/ask.py
@@ -25,8 +25,8 @@ def get_ask_config(source_root):
 	if source_root:
 		source_root += '/'
 
-	if os.path.isfile(source_root + 'Askfile'):
-		with open(source_root + 'Askfile', 'r') as f:
+	if os.path.isfile(f'{source_root}Askfile':
+		with open(f'{source_root}Askfile', 'r') as f:
 			return json.loads(''.join(f.readlines()))
 
 	return {}
@@ -83,7 +83,7 @@ def maybe_place_space_before(parsed, token_val):
 
 	if parsed and parsed[-1] in ['\n', '\t', '(', ' ', '.']:
 		prefix = ''
-	parsed += prefix + token_val + ' '
+	parsed += f'{prefix}{token_val} '
 
 	return parsed
 
@@ -95,11 +95,11 @@ def transpile_decorator(decorator):
 	}
 
 	try:
-		return '\n@' + decorators[decorator]
+		return f'\n@{decorators[decorator]}'
 	except KeyError:
 		for key, value in decorators.items():
 			if decorator[:len(key)] == key:
-				return '\n@' + value + decorator[len(key):]
+				return f'\n@{value}{decorator[len(key):]}'
 		return ''
 
 
@@ -113,7 +113,7 @@ def route_params(route_path):
 			is_param = True
 		elif char == '>':
 			is_param = False
-			params_str += tmp + ', '
+			params_str += f'{tmp}, '
 			tmp = ''
 		elif is_param and char not in [' ' + '\t', '\n']:
 			tmp += char
@@ -206,7 +206,7 @@ def parser(tokens):
 				tab_level = get_current_tab_level(parsed)
 				parsed += '\n' + tab_level + 'db.session.commit()'
 		elif token_type == 'STR':
-			parsed += '"' + token_val + '"'
+			parsed += f'\"{token_val}\"'
 		elif token_type == 'KEYWORD':
 			parsed = maybe_place_space_before(parsed, token_val)
 		elif token_type == 'VAR':
@@ -224,37 +224,36 @@ def parser(tokens):
 				if token_index < len(tokens) and tokens[token_index + 1][0] == 'STR':
 					next_token_val = tokens[token_index + 1][1]
 
-					parsed += '@app.route(\'' + next_token_val + '\', methods=[\'' + token_val[1:] + '\'])' + suffix
+					parsed += f'@app.route(\'{next_token_val}\', methods=[\'{token_val[1:]}\']){suffix}'
 
 					if is_decorator:
 						parsed += decorator + '\n'
 
-					parsed += 'def ' + token_val[1:] + route_path_to_func_name(next_token_val) + '(' + route_params(
-						next_token_val)
+					parsed += f'def {token_val[1:]}{route_path_to_func_name(next_token_val)}({route_params(next_token_val)}'
 					is_skip = True
 					is_decorator = False
 			elif token_val in ['quickSet', 'deep', 'serialize', 'respond']:
 				prefix = 'AskLibrary.'
 
 				if token_val in ['respond']:
-					prefix = 'return ' + prefix
+					prefix = f'return {prefix}'
 
-				parsed += prefix + token_val + '('
+				parsed += f'{prefix}{token_val}('
 			elif token_val == 'respond':
 				parsed += 'return jsonify('
 			elif token_val == 'status':
 				parsed += 'abort(Response('
 				add_parenthesis_at_en_of_line = True
 			else:
-				parsed += token_val + '('
+				parsed += f'{token_val}('
 		elif token_type == 'DB_CLASS':
-			parsed += '\nclass ' + token_val + '(db.Model)'
+			parsed += f'\nclass {token_val}(db.Model)'
 		elif token_type == 'FUNC_DEF':
 			if token_val == '_init':
 				token_val = '__init__'
-			parsed += 'def ' + token_val + '('
+			parsed += f'def {token_val}('
 		elif token_type == 'KEY':
-			parsed += '\'' + token_val + '\''
+			parsed += f'\'{token_val}\''
 		elif token_type == 'DEC':
 			is_decorator = True
 			decorator = transpile_decorator(token_val)
@@ -443,7 +442,7 @@ def parse_and_prepare(tokens):
 	global flask_end_boilerplate
 
 	parsed = parser(tokens)
-	parsed = flask_boilerplate + '\n' + parsed
+	parsed = f'{flask_boilerplate}\n{parsed}'
 	parsed += flask_end_boilerplate
 
 	return parsed
@@ -498,7 +497,7 @@ def startup(file_name):
 			from importlib.machinery import SourceFileLoader
 
 			print('\33[1m' + 'Loading database... ' + '\033[0m', end='')
-			app = SourceFileLoader("app", os.getcwd() + '/' + 'app.py').load_module()
+			app = SourceFileLoader("app", f'{os.getcwd()}/app.py').load_module()
 			app.db.create_all()
 			print('DONE')
 
@@ -737,7 +736,7 @@ if __name__ == '__main__':
 				is_dev = True
 
 		source_file_name = sys.argv[1]
-		if os.path.isfile(os.getcwd() + '/' + source_file_name):
+		if os.path.isfile(f'{os.getcwd()}/{source_file_name}'):
 			ask_config = get_ask_config(get_root_from_file_path(source_file_name))
 			set_boilerplate()
 			startup(source_file_name)


### PR DESCRIPTION
#41 I changed most of the string concatenations to f-strings. I did leave all of the concatenations involving ANSI escape codes as they originally were because I could not find out how the f-string conversion might affect them. 

Lastly, I fixed two typos in the markdown documentation:
"aks.py" -> "ask.py" in the readme
"signle quotes" -> "single quotes" in the contributing